### PR TITLE
fix: resolve Rollup TypeScript warnings for CSS modules and React 19 …

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,7 +28,13 @@ export default [
       peerDepsExternal(),
       resolve(),
       commonjs(),
-      typescript({ tsconfig: "./tsconfig.json" }),
+      typescript({
+        tsconfig: "./tsconfig.rollup.json",
+        compilerOptions: {
+          outDir: "dist",
+        },
+        exclude: ["node_modules", "**/*.test.ts", "**/*.spec.ts"],
+      }),
       terser(),
       postcss(),
     ],
@@ -54,7 +60,13 @@ export default [
       peerDepsExternal(),
       resolve(),
       commonjs(),
-      typescript({ tsconfig: "./tsconfig.json" }),
+      typescript({
+        tsconfig: "./tsconfig.rollup.json",
+        compilerOptions: {
+          outDir: "dist/hooks",
+        },
+        exclude: ["node_modules", "**/*.test.ts", "**/*.spec.ts"],
+      }),
       terser(),
       postcss(),
     ],
@@ -79,7 +91,13 @@ export default [
       peerDepsExternal(),
       resolve(),
       commonjs(),
-      typescript({ tsconfig: "./tsconfig.json" }),
+      typescript({
+        tsconfig: "./tsconfig.rollup.json",
+        compilerOptions: {
+          outDir: "dist/lib",
+        },
+        exclude: ["node_modules", "**/*.test.ts", "**/*.spec.ts"],
+      }),
       terser(),
       postcss(),
     ],

--- a/src/components/Popover/PopoverContext.tsx
+++ b/src/components/Popover/PopoverContext.tsx
@@ -3,8 +3,8 @@ import { createContext, useContext } from "react";
 interface PopoverContextType {
   isOpen: boolean;
   setIsOpen: (value: boolean) => void;
-  triggerRef: React.RefObject<HTMLButtonElement>;
-  contentRef: React.RefObject<HTMLDivElement>;
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
+  contentRef: React.RefObject<HTMLDivElement | null>;
 }
 
 export const PopoverContext = createContext<PopoverContextType | undefined>(

--- a/src/components/TimePicker/TimePicker.tsx
+++ b/src/components/TimePicker/TimePicker.tsx
@@ -55,7 +55,7 @@ export default function TimePicker({
   };
 
   const scrollToSelectedItem = (
-    ref: React.RefObject<HTMLDivElement>,
+    ref: React.RefObject<HTMLDivElement | null>,
     value: string,
   ) => {
     if (ref.current) {

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/src/hooks/usePosition.ts
+++ b/src/hooks/usePosition.ts
@@ -3,8 +3,8 @@ import { Position, Placement } from "../types";
 import { calculatePosition } from "../utils/calculatePosition";
 
 export function usePosition(
-  triggerRef: React.RefObject<HTMLButtonElement>,
-  contentRef: React.RefObject<HTMLDivElement>,
+  triggerRef: React.RefObject<HTMLButtonElement | null>,
+  contentRef: React.RefObject<HTMLDivElement | null>,
   anchor: Placement = "bottom",
   align: "start" | "center" | "end" = "center",
   sideOffset: number = 8,

--- a/tsconfig.rollup.json
+++ b/tsconfig.rollup.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "DOM.Iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "noEmit": false,
+    "declaration": false,
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
…refs. Add CSS module declarations, configure Rollup with tsconfig.rollup.json, and update RefObject types for React 19 compatibility.